### PR TITLE
Update orbit_fitter_gc.py

### DIFF
--- a/build/lib/mwahpy/orbit_fitter_gc.py
+++ b/build/lib/mwahpy/orbit_fitter_gc.py
@@ -148,7 +148,7 @@ def chi_squared(params, data=[], normal=(0, 0, 0), point=(1, 0, 0)):
 
 #takes in data, then fits a Great Circle to that data and
 #minimizes the chi_squared to fit an orbit to the data
-def optimize(data_opt, max_it, bounds, guess, mode, **kwargs)
+def optimize(data_opt, max_it, bounds, guess, mode, **kwargs):
 
     #compute the preferred galactocentric spherical frame to fit this orbit in
     #(should be close to the orbital plane of the observed data)


### PR DESCRIPTION
I found a syntax error in the optimize function in this file. It was simply missing the colon in the definition. This brings up an error when downloading mwahpy, and is easy to spot and fix, but a change should be made to fix this.