### PR TITLE
Support new output format with LMC info and fix Timestep.copy() infinite recursion

### DIFF
--- a/mwahpy/output_handler.py
+++ b/mwahpy/output_handler.py
@@ -46,18 +46,30 @@ def remove_header(f):
         f.readline()
     else:
         old_format = False
-        f.readline() 
+        f.readline()
 
-
-    #next line has COM info
-    line = f.readline() 
+    #next line has COM info (or hasLMC in new format)
+    line = f.readline()
+    lmc_pos, lmc_vel, haslmc_header_lines = None, None, 0
+    has_lmc = False
+    if 'centerOfMass' not in line:  # New format: hasLMC line
+        has_lmc = int(line.strip().split('=')[1].strip()) == 1
+        haslmc_header_lines = 2 if has_lmc else 1  # hasLMC line + optional LMC pos/vel line
+        line = f.readline()  # centerOfMass line
     line = line.split(',')
     line[0] = line[0].strip('centerOfMass = ')
     line[3] = line[3].strip('centerOfMomentum = ')
     comass = [float(line[0]), float(line[1]), float(line[2])]
     comom = [float(line[3]), float(line[4]), float(line[5])]
+    if has_lmc:
+        lmc_line = f.readline()
+        parts = lmc_line.split(',')
+        lmc_pos = [float(parts[0].strip().replace('LMC position = ', '')),
+                   float(parts[1].strip()), float(parts[2].strip())]
+        lmc_vel = [float(parts[3].strip().replace('LMC velocity = ', '')),
+                   float(parts[4].strip()), float(parts[5].strip())]
 
-    return comass, comom, has_bodies_tag, old_format
+    return comass, comom, has_bodies_tag, old_format, lmc_pos, lmc_vel, haslmc_header_lines
 
 #parses a milkyway ".out" file and returns a Timestep class structure
 def read_output(f, start=None, stop=None):
@@ -79,14 +91,14 @@ def read_output(f, start=None, stop=None):
     f = open(f, 'r')
 
     #remove the header, get relevant info from header
-    comass, comom, has_bodies_tag, old_format = remove_header(f)
+    comass, comom, has_bodies_tag, old_format, lmc_pos, lmc_vel, haslmc_header_lines = remove_header(f)
 
     # Adjust file length for progress bar to account for header lines
     if progress_bars:
         if old_format:
             header_lines = 6 if has_bodies_tag else 5
         else:
-            header_lines = 5 if has_bodies_tag else 4
+            header_lines = 5 if has_bodies_tag else 4 + haslmc_header_lines
         flen -= header_lines
 
     if has_bodies_tag: #have to account for the </bodies> tag at the end of the file
@@ -167,7 +179,11 @@ def read_output(f, start=None, stop=None):
         'center_of_mass': comass,
         'center_of_momentum': comom
     }
-    
+    if lmc_pos is not None:
+        timestep_kwargs['lmc_position'] = lmc_pos
+    if lmc_vel is not None:
+        timestep_kwargs['lmc_velocity'] = lmc_vel
+
     # Map data to kwargs for Timestep class
     for col_name in column_names:
         # Handle special cases for column name mapping

--- a/mwahpy/timestep.py
+++ b/mwahpy/timestep.py
@@ -286,15 +286,17 @@ class Timestep():
         self.msol = self.mass * struct_to_sol
 
         #position information
-        if not 'r' in self._provided_vals:
+        # Compute r if missing - avoids infinite recursion when in _provided_vals but not __dict__
+        if not 'r' in self._provided_vals or 'r' not in self.__dict__:
             self.r = (self.x**2 + self.y**2 + self.z**2)**0.5
         self.dist = ((self.x + 8)**2 + self.y**2 + self.z**2)**0.5
         self.R = (self.x**2 + self.y**2)**0.5
 
         #galactic coordinate information
-        if not 'l' in self._provided_vals:
+        # Compute l/b if missing - avoids infinite recursion when in _provided_vals but not __dict__
+        if not 'l' in self._provided_vals or 'l' not in self.__dict__:
             self.l = np.arctan2(self.y, self.x + 8)*180/np.pi
-        if not 'b' in self._provided_vals:
+        if not 'b' in self._provided_vals or 'b' not in self.__dict__:
             self.b = np.arcsin(self.z/self.dist)*180/np.pi
 
         #ICRS information


### PR DESCRIPTION
## Summary

Adds support for the new milkyway .out file format that includes LMC  information, and fixes an infinite recursion bug in `Timestep.copy()`.

## Changes

### output_handler.py
- **New format support**: Handle output files with a `hasLMC` header line before the center-of-mass line
- **LMC data parsing**: When `hasLMC=1`, parse LMC position and velocity from the header
- **Timestep integration**: Pass `lmc_position` and `lmc_velocity` to the Timestep via kwargs when present
- **Progress bar**: Correct header line count for the new format when computing file length

### timestep.py
- **Bug fix**: Prevent infinite recursion in `calc_basic()` when `l`, `b`, or `r` are in `_provided_vals` but missing from `__dict__` (e.g., from output files with those columns but inconsistent data)
- Previously, `calc_basic()` skipped computing these values, then accessed them for `SkyCoord`, which triggered `__getattr__` → `calc_basic()` again
- Fix: Compute `l`, `b`, and `r` whenever they are missing from `__dict__`, regardless of `_provided_vals`