### PR TITLE
Fix update() flags and Timestep copy 

### DIFF
--- a/mwahpy/timestep.py
+++ b/mwahpy/timestep.py
@@ -252,18 +252,14 @@ class Timestep():
     #this can't be done by iterating over the object, since comass etc. have to be copied as well
     def copy(self):
         out = Timestep()
-        if self.have_basic: #these set the proper flags and index_list, etc. but don't cost computation time
-            out.calc_basic()
-        if self.have_rvpm:
-            out.calc_rvpm()
-        if self.have_energy:
-            out.calc_energy()
-        for key in self.__dict__.keys():
-            if type(out[str(key)]) == type(np.array([])) or type(out[str(key)]) == type([]):
-                out[str(key)] = self[str(key)].copy()
+        for key in list(self.__dict__.keys()):
+            val = self.__dict__[key]
+            if isinstance(val, np.ndarray):
+                out.__dict__[key] = val.copy()
+            elif isinstance(val, list):
+                out.__dict__[key] = list(val)
             else:
-                out[str(key)] = self[str(key)]
-
+                out.__dict__[key] = val
         return out
 
     #---------------------------------------------------------------------------

--- a/mwahpy/timestep.py
+++ b/mwahpy/timestep.py
@@ -242,8 +242,8 @@ class Timestep():
 
         #the positions and velocities have not changed since updating
         #(since we just updated)
-        changed_pos = False
-        changed_vel = False
+        self.changed_pos = False
+        self.changed_vel = False
 
         if verbose:
             print('Done updating')


### PR DESCRIPTION
## Summary
Fixes a bug in `Timestep.update()` where `changed_pos` and `changed_vel` were never reset after an update.
Avoid accessing out[key] during the copy loop; use val from the source and assign directly to out.__dict__ so attributes like vlos are not triggered before they exist.


